### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ PCF and product tiles Concourse Pipelines:
 
 -----------------------------------------------------------------------------
 
-Following in an example on how to `fly` a pipeline:
+Following is an example on how to `fly` a pipeline:
 
 ```
 >	fly -t concourse-[ENV] login -c https://<CONCOURSE-URL> -k


### PR DESCRIPTION
Change this:

-Following in an example on how to `fly` a pipeline:

To this:

+Following is an example on how to `fly` a pipeline: