### PR TITLE
jq input was missing from upgrade-tile pipelines

### DIFF
--- a/pipelines/upgrade-tile/multiple-pipeline.yml
+++ b/pipelines/upgrade-tile/multiple-pipeline.yml
@@ -75,6 +75,13 @@ resources:
   type: time
   source: {interval: 24h}
 
+- name: jq
+  type: github-release
+  source:
+    user: stedolan
+    repository: jq
+    access_token: ((git_token))
+
 jobs:
 - name: scheduler
   plan:
@@ -150,6 +157,10 @@ jobs:
         globs:
         - "*linux-amd64*"
       passed: [upload-product-rabbitmq]
+    - get: jq
+      params:
+        globs:
+        - "*linux64*"
 
   - task: upload-stemcell
     file: pipelines-repo/tasks/stemcell-uploader/task.yml

--- a/pipelines/upgrade-tile/pipeline.yml
+++ b/pipelines/upgrade-tile/pipeline.yml
@@ -40,6 +40,13 @@ resources:
   type: time
   source: {interval: 24h}
 
+- name: jq
+  type: github-release
+  source:
+    user: stedolan
+    repository: jq
+    access_token: ((git_token))
+
 jobs:
 - name: scheduler
   plan:
@@ -98,6 +105,10 @@ jobs:
         globs:
         - "*linux-amd64*"
       passed: [upload-product]
+    - get: jq
+      params:
+        globs:
+        - "*linux64*"
 
   - task: upload-stemcell
     file: pipelines-repo/tasks/stemcell-uploader/task.yml


### PR DESCRIPTION
Add jq as input so that the stemcell-upload task will run successfully.

* What is the PR about?

Upgrade pipelines will not run without this change.

* Have you tested it?

Ran into this with customer and fixed it and tested there. I did NOT test the multiple pipelines manually just the single.

* Is there any additional work required to complete this feature you are submitting the PR for?
