### PR TITLE
fix certificate generation for isolation segments

### DIFF
--- a/pipelines/tiles/isolation-segment/params.yml
+++ b/pipelines/tiles/isolation-segment/params.yml
@@ -53,7 +53,9 @@ haproxy_forward_tls: disable # enable|disable
 haproxy_forward_tls_enable_backend_ca: ''
 haproxy_max_buffer_size: 16384
 haproxy_ssl_ciphers: ''
-isolation_segment_domains: '' # cfapps-ext.env.company.com
+
+# comma seperated list of comma separated domains usually preceded by a *
+isolation_segment_domains: '' # *.cfapps-ext.env.company.com,*.cfapps-web.env.company.com
 networking_poe_ssl_name: ''
 networking_poe_ssl_cert_pem: ''
 networking_poe_ssl_cert_private_key_pem: ''

--- a/tasks/config-is-tile/task.sh
+++ b/tasks/config-is-tile/task.sh
@@ -13,10 +13,7 @@ chmod +x ./jq/jq-linux64
 JQ_CMD=./jq/jq-linux64
 
 if [[ -z "$NETWORKING_POE_SSL_CERT_PEM" ]]; then
-DOMAINS=$(cat <<-EOF
-  {"domains": $ISOLATION_SEGMENT_DOMAINS }
-EOF
-)
+  DOMAINS=$(echo $ISOLATION_SEGMENT_DOMAINS | jq --raw-input -c '{"domains": (. | split(" "))}')
 
   CERTIFICATES=`$OM_CMD -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -p "/api/v0/certificates/generate" -x POST -d "$DOMAINS"`
 


### PR DESCRIPTION
Certificate generation was failing because the JSON payload being passed
in to Opsman was not correct. The JSON object needs to be an array even
if of size 1. Without this fix the om-linux call will respond with "could not
execute 'curl' server responded with an error."

This solution was borrowed from:

https://github.com/pivotal-cf/pcf-pipelines/blob/master/functions/generate_cert.sh

* What is the PR about?
* Have you tested it?
* Is there any additional work required to complete this feature you are submitting the PR for?
