### PR TITLE
fix missing input in upgrade pipeline

### DIFF
--- a/pipelines/upgrade-tile/pipeline.yml
+++ b/pipelines/upgrade-tile/pipeline.yml
@@ -192,6 +192,10 @@ jobs:
         globs: []
       passed: [stage-product]
       trigger: true
+    - get: jq
+      params:
+        globs:
+        - "*linux64*"
 
   - task: apply-changes
     file: pipelines-repo/tasks/apply-changes/task.yml


### PR DESCRIPTION
Apply changes task in upgrade pipeline is failing because the jq input is missing in pipeline configuration. 

https://github.com/rahul-kj/pcf-concourse-pipelines/blob/master/tasks/apply-changes/task.yml#L16-L19