### PR TITLE
Support Xenial stemcell product slug in stemcell-uploader task

### DIFF
--- a/tasks/stemcell-uploader/task.sh
+++ b/tasks/stemcell-uploader/task.sh
@@ -30,7 +30,11 @@ if [[ ! -z "$SC_VERSION" ]]; then
     $PIVNET_CLI login --api-token="$PIVNET_API_TOKEN"
 
     set +e
-    RESPONSE=`$PIVNET_CLI releases -p stemcells | grep $SC_VERSION`
+    if [ "$STEMCELL_TYPE"="xenial" ]; then
+      RESPONSE=`$PIVNET_CLI releases -p stemcells-ubuntu-xenial | grep $SC_VERSION`
+    else 
+      RESPONSE=`$PIVNET_CLI releases -p stemcells | grep $SC_VERSION`
+    fi
     set -e
 
     if [[ -z "$RESPONSE" ]]; then

--- a/tasks/stemcell-uploader/task.sh
+++ b/tasks/stemcell-uploader/task.sh
@@ -19,7 +19,7 @@ SC_VERSION=`cat ./pivnet-product/metadata.json | $JQ_CMD -r '.Dependencies[] | s
 
 if [[ ! -z "$SC_VERSION" ]]; then
   STEMCELL_NAME=bosh-stemcell-$SC_VERSION-$IAAS_TYPE-ubuntu-$STEMCELL_TYPE-go_agent.tgz
-  if [ "$STEMCELL_TYPE"="xenial"]; then
+  if [ "$STEMCELL_TYPE"="xenial" ]; then
     $PRODUCT_SLUG="stemcells-ubuntu-xenial"
   else
     $PRODUCT_SLUG="stemcells"

--- a/tasks/stemcell-uploader/task.sh
+++ b/tasks/stemcell-uploader/task.sh
@@ -40,7 +40,11 @@ if [[ ! -z "$SC_VERSION" ]]; then
     if [[ -z "$RESPONSE" ]]; then
       wget --show-progress https://s3.amazonaws.com/bosh-core-stemcells/vsphere/$STEMCELL_NAME
     else
-      $PIVNET_CLI download-product-files -p stemcells -r $SC_VERSION -g "*$IAAS_TYPE*" --accept-eula
+      if [ "$STEMCELL_TYPE"="xenial" ]; then
+        $PIVNET_CLI download-product-files -p stemcells-ubuntu-xenial -r $SC_VERSION -g "*$IAAS_TYPE*" --accept-eula
+      else
+        $PIVNET_CLI download-product-files -p stemcells -r $SC_VERSION -g "*$IAAS_TYPE*" --accept-eula
+      fi
     fi
 
     SC_FILE_PATH=`find ./ -name *.tgz`

--- a/tasks/stemcell-uploader/task.sh
+++ b/tasks/stemcell-uploader/task.sh
@@ -20,9 +20,9 @@ SC_VERSION=`cat ./pivnet-product/metadata.json | $JQ_CMD -r '.Dependencies[] | s
 if [[ ! -z "$SC_VERSION" ]]; then
   STEMCELL_NAME=bosh-stemcell-$SC_VERSION-$IAAS_TYPE-ubuntu-$STEMCELL_TYPE-go_agent.tgz
   if [ "$STEMCELL_TYPE"="xenial" ]; then
-    $PRODUCT_SLUG="stemcells-ubuntu-xenial"
+    PRODUCT_SLUG="stemcells-ubuntu-xenial"
   else
-    $PRODUCT_SLUG="stemcells"
+    PRODUCT_SLUG="stemcells"
   fi
 
   DIAGNOSTIC_REPORT=$($OM_CMD -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -s -p /api/v0/diagnostic_report)

--- a/tasks/stemcell-uploader/task.sh
+++ b/tasks/stemcell-uploader/task.sh
@@ -19,6 +19,11 @@ SC_VERSION=`cat ./pivnet-product/metadata.json | $JQ_CMD -r '.Dependencies[] | s
 
 if [[ ! -z "$SC_VERSION" ]]; then
   STEMCELL_NAME=bosh-stemcell-$SC_VERSION-$IAAS_TYPE-ubuntu-$STEMCELL_TYPE-go_agent.tgz
+  if [ "$STEMCELL_TYPE"="xenial"]; then
+    $PRODUCT_SLUG="stemcells-ubuntu-xenial"
+  else
+    $PRODUCT_SLUG="stemcells"
+  fi
 
   DIAGNOSTIC_REPORT=$($OM_CMD -t https://$OPS_MGR_HOST -u $OPS_MGR_USR -p $OPS_MGR_PWD -k curl -s -p /api/v0/diagnostic_report)
   STEMCELL_EXISTS=$(echo $DIAGNOSTIC_REPORT | $JQ_CMD -r --arg STEMCELL_NAME $STEMCELL_NAME '.stemcells | contains([$STEMCELL_NAME])')
@@ -30,21 +35,13 @@ if [[ ! -z "$SC_VERSION" ]]; then
     $PIVNET_CLI login --api-token="$PIVNET_API_TOKEN"
 
     set +e
-    if [ "$STEMCELL_TYPE"="xenial" ]; then
-      RESPONSE=`$PIVNET_CLI releases -p stemcells-ubuntu-xenial | grep $SC_VERSION`
-    else 
-      RESPONSE=`$PIVNET_CLI releases -p stemcells | grep $SC_VERSION`
-    fi
+    RESPONSE=`$PIVNET_CLI releases -p $PRODUCT_SLUG | grep $SC_VERSION`
     set -e
 
     if [[ -z "$RESPONSE" ]]; then
       wget --show-progress https://s3.amazonaws.com/bosh-core-stemcells/vsphere/$STEMCELL_NAME
     else
-      if [ "$STEMCELL_TYPE"="xenial" ]; then
-        $PIVNET_CLI download-product-files -p stemcells-ubuntu-xenial -r $SC_VERSION -g "*$IAAS_TYPE*" --accept-eula
-      else
-        $PIVNET_CLI download-product-files -p stemcells -r $SC_VERSION -g "*$IAAS_TYPE*" --accept-eula
-      fi
+      $PIVNET_CLI download-product-files -p $PRODUCT_SLUG -r $SC_VERSION -g "*$IAAS_TYPE*" --accept-eula
     fi
 
     SC_FILE_PATH=`find ./ -name *.tgz`


### PR DESCRIPTION
Looks like Pivnet split stemcells into two separate product slugs.  This PR adds logic so that it attempts to pull the stemcell from the appropriate slug based on `$STEMCELL_TYPE`.
