### PR TITLE
Fixes bug in conditional for STEMCELL_TYPE

### DIFF
--- a/tasks/stemcell-uploader/task.sh
+++ b/tasks/stemcell-uploader/task.sh
@@ -19,7 +19,7 @@ SC_VERSION=`cat ./pivnet-product/metadata.json | $JQ_CMD -r '.Dependencies[] | s
 
 if [[ ! -z "$SC_VERSION" ]]; then
   STEMCELL_NAME=bosh-stemcell-$SC_VERSION-$IAAS_TYPE-ubuntu-$STEMCELL_TYPE-go_agent.tgz
-  if [ "$STEMCELL_TYPE"="xenial" ]; then
+  if [ "$STEMCELL_TYPE" = "xenial" ]; then
     PRODUCT_SLUG="stemcells-ubuntu-xenial"
   else
     PRODUCT_SLUG="stemcells"


### PR DESCRIPTION
Bash is pretty specific about whitespace, so this conditional doesn't work without space between the objects being compared.
